### PR TITLE
Fix linting and formatting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -101,6 +101,7 @@ deps =
     furo
     sphinx
 commands =
+    python --version
     sphinx-apidoc \
         --force \
         --implicit-namespaces \

--- a/src/repoman/cli.py
+++ b/src/repoman/cli.py
@@ -77,7 +77,7 @@ def parse_repo_types() -> dict[str, set[str]]:
     return repo_types
 
 
-def check_missing_repos(path: Path, repo_types: dict[str, set[str]]) -> None | NoReturn:
+def check_missing_repos(path: Path, repo_types: dict[str, set[str]]) -> Union[None, NoReturn]:
     missing = set()
     directories = {str(directory) for directory in path.iterdir()}
 

--- a/src/repoman/cli.py
+++ b/src/repoman/cli.py
@@ -14,9 +14,7 @@ REPO_TYPES_CFG = "repo-types.cfg"
 
 def check_if_allowed(path: Path) -> bool | NoReturn:
     if REPO_TYPES_CFG not in (str(item) for item in path.iterdir()):
-        print(
-            f"{FAIL}The current directory is not configured for repository management{ENDC}"
-        )
+        print(f"{FAIL}The current directory is not configured for repository management{ENDC}")
         sys.exit(1)
 
     return True
@@ -90,7 +88,7 @@ def check_missing_repos(path: Path, repo_types: dict[str, set[str]]) -> None | N
     if missing:
         print(f"{FAIL}The following repositories are configured but do not exist:")
         for repo in missing:
-            print("\t{repo}")
+            print(f"\t{repo}")
         sys.exit(1)
 
     return None
@@ -128,7 +126,11 @@ def main():
 
     if args.unconfigured:
         for directory in sorted(path.iterdir()):
-            if directory.is_dir() and str(directory) not in repo_types["all"] and str(directory) not in repo_types["ignore"]:
+            if (
+                directory.is_dir()
+                and str(directory) not in repo_types["all"]
+                and str(directory) not in repo_types["ignore"]
+            ):
                 print(directory)
 
     if args.list:
@@ -143,4 +145,3 @@ def main():
                     if repo in seen:
                         print(repo)
                     seen.add(repo)
-

--- a/src/repoman/cli.py
+++ b/src/repoman/cli.py
@@ -4,7 +4,7 @@ import argparse
 import configparser
 import sys
 from pathlib import Path
-from typing import NoReturn
+from typing import NoReturn, Union
 
 
 FAIL = "\033[91m"
@@ -12,7 +12,7 @@ ENDC = "\033[0m"
 REPO_TYPES_CFG = "repo-types.cfg"
 
 
-def check_if_allowed(path: Path) -> bool | NoReturn:
+def check_if_allowed(path: Path) -> Union[bool, NoReturn]:
     if REPO_TYPES_CFG not in (str(item) for item in path.iterdir()):
         print(f"{FAIL}The current directory is not configured for repository management{ENDC}")
         sys.exit(1)

--- a/test/test_repoman.py
+++ b/test/test_repoman.py
@@ -1,2 +1,4 @@
 def test_package_is_importable():
     import repoman
+
+    print(repoman)


### PR DESCRIPTION
## Description of issue

Linting and formatting were failing after the initial setup.

## Description of solution

Run `tox -e format -- src test` and fix errors from `tox -e lint`.
