### PR TITLE
Fix docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,9 +9,11 @@ formats:
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.10"
+    python: "3.9"
 
 python:
   install:
     - method: pip
       path: .
+      extra_requirements:
+        - docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,12 @@ exclude =
 console_scripts =
     repoman = repoman.cli:main
 
+[options.extras_require]
+docs =
+    furo
+    sphinx
+    sphinx-autobuild
+
 ######################
 # Tool configuration #
 ######################
@@ -97,9 +103,8 @@ commands =
     flake8 {posargs:src test}
 
 [testenv:docs]
-deps =
-    furo
-    sphinx
+extras =
+    docs
 commands =
     python --version
     sphinx-apidoc \
@@ -114,10 +119,8 @@ commands =
     sphinx-build -n -W --keep-going -b html docs/ docs/_build/
 
 [testenv:devdocs]
-deps =
-    furo
-    sphinx
-    sphinx-autobuild
+extras =
+    docs
 commands =
     sphinx-apidoc \
         --force \


### PR DESCRIPTION
## Description of issue

tox and Read the Docs differ in how they need to grab the appropriate build dependencies for the documentation.

## Description of solution

Move documentation dependencies to an extras configuration so both tools will install the dependencies correctly.