### PR TITLE
Specify trusted publisher environment

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -115,6 +115,7 @@ jobs:
     needs: [format, lint, typecheck, test, docs]
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Description of issue

PyPI and GitHub recommend specifying an environment for trusted publishing to minimize blast radii.

## Description of solution

Add the configured environment to the workflow configuration.