### PR TITLE
Organize package and start testing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `init` command to create a new config file
+- `edit` command to edit a config file manually
+- `implode` command to remove configuration
+- `sniff` command to inspect configuration and issues
+- More confirmations for exceptional cases
+- A start to unit tests
+
+### Changed
+
+- Move root options to new `sniff` command
+- Move subcommands and utilities to individual modules
+- Updated error and confirmation messaging
+- Open long repo lists in pager
+
 ## [0.0.5] - 2023-12-09
 
 ### Changed

--- a/src/repo_man/cli.py
+++ b/src/repo_man/cli.py
@@ -1,164 +1,34 @@
 import configparser
-import sys
-from pathlib import Path
-from typing import NoReturn, Union
 
 import click
 
-
-FAIL = "\033[91m"
-ENDC = "\033[0m"
-REPO_TYPES_CFG = "repo-man.cfg"
-
-
-def check_if_allowed(path: Path) -> Union[bool, NoReturn]:
-    if REPO_TYPES_CFG not in (str(item) for item in path.iterdir()):
-        print(f"{FAIL}The current directory is not configured for repository management{ENDC}")
-        sys.exit(1)
-
-    return True
+from repo_man.commands.add import add
+from repo_man.commands.edit import edit
+from repo_man.commands.flavors import flavors
+from repo_man.commands.implode import implode
+from repo_man.commands.init import init
+from repo_man.commands.list_repos import list_repos
+from repo_man.commands.sniff import sniff
+from repo_man.consts import REPO_TYPES_CFG
 
 
-def parse_repo_types(config: configparser.ConfigParser) -> dict[str, set[str]]:
-    repo_types: dict[str, set[str]] = {"all": set()}
-    for section in config.sections():
-        repos = {repo for repo in config[section]["known"].split("\n") if repo}
-        repo_types[section] = repos
-        if section != "ignore":
-            repo_types["all"].update(repos)
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.version_option(package_name="repo-man")
+@click.pass_context
+def cli(context):
+    """Manage repositories of different types"""
 
-    return repo_types
-
-
-def check_missing_repos(path: Path, repo_types: dict[str, set[str]]) -> None:
-    missing = set()
-    directories = {str(directory) for directory in path.iterdir()}
-
-    for repo in sorted(repo_types["all"]):
-        if repo not in directories:
-            missing.add(repo)
-
-    if missing:
-        print(f"{FAIL}The following repositories are configured but do not exist:")
-        for repo in missing:
-            print(f"\t{repo}")
-        sys.exit(1)
-
-    return None
-
-
-def get_valid_repo_types():
     config = configparser.ConfigParser()
     config.read(REPO_TYPES_CFG)
-    valid_repo_types = parse_repo_types(config)
-    return sorted(set(valid_repo_types.keys()))
+    context.obj = config
 
 
 def main():
-    path = Path(".")
-    check_if_allowed(path)
-
-    config = configparser.ConfigParser()
-    config.read(REPO_TYPES_CFG)
-    valid_repo_types = parse_repo_types(config)
-    check_missing_repos(path, valid_repo_types)
-
+    cli.add_command(add)
+    cli.add_command(edit)
+    cli.add_command(flavors)
+    cli.add_command(implode)
+    cli.add_command(init)
+    cli.add_command(list_repos)
+    cli.add_command(sniff)
     cli()
-
-
-@click.group(invoke_without_command=True, context_settings={"help_option_names": ["-h", "--help"]})
-@click.version_option(package_name="repo-man")
-@click.option("-k", "--known", is_flag=True, help="List known repository types")
-@click.option("-u", "--unconfigured", is_flag=True, help="List repositories without a configured type")
-@click.option("-d", "--duplicates", is_flag=True, help="List repositories with more than one configured type")
-# @click.option("-v", "--verbose", "verbosity", count=True)
-def cli(known: bool, unconfigured: bool, duplicates: bool):
-    """Manage repositories of different types"""
-
-    path = Path(".")
-    config = configparser.ConfigParser()
-    config.read(REPO_TYPES_CFG)
-    valid_repo_types = parse_repo_types(config)
-
-    if known:
-        known_repo_types = sorted(
-            [repo_type for repo_type in valid_repo_types if repo_type != "all" and repo_type != "ignore"]
-        )
-        for repo_type in known_repo_types:
-            print(repo_type)
-
-    if unconfigured:
-        for directory in sorted(path.iterdir()):
-            if (
-                directory.is_dir()
-                and str(directory) not in valid_repo_types["all"]
-                and str(directory) not in valid_repo_types.get("ignore", [])
-            ):
-                print(directory)
-
-    if duplicates:
-        seen = set()
-        for repo_type in valid_repo_types:
-            if repo_type != "all" and repo_type != "ignore":
-                for repo in valid_repo_types[repo_type]:
-                    if repo in seen:
-                        print(repo)
-                    seen.add(repo)
-
-
-@cli.command(name="list", help="The type of repository to manage")
-@click.option("-t", "--type", "repo_type", type=click.Choice(get_valid_repo_types()), show_choices=False, required=True)
-def list_repos(repo_type: str):
-    """List matching repositories"""
-
-    config = configparser.ConfigParser()
-    config.read(REPO_TYPES_CFG)
-    valid_repo_types = parse_repo_types(config)
-
-    for repo in valid_repo_types[repo_type]:
-        print(repo)
-
-    return None
-
-
-@cli.command
-@click.argument("repo", type=click.Path(exists=True, file_okay=False))
-def flavors(repo: str):
-    """List the configured types for a repository"""
-
-    config = configparser.ConfigParser()
-    config.read(REPO_TYPES_CFG)
-
-    found = set()
-
-    for section in config.sections():
-        if section == "ignore":
-            continue
-        if repo in config[section]["known"].split("\n"):
-            found.add(section)
-
-    for repository in sorted(found):
-        print(repository)
-
-
-@cli.command
-@click.option("-t", "--type", "repo_types", multiple=True, help="The type of the repository", required=True)
-@click.argument("repo", type=click.Path(exists=True, file_okay=False))
-def add(repo: str, repo_types: list):
-    """Add a new repository"""
-
-    config = configparser.ConfigParser()
-    config.read(REPO_TYPES_CFG)
-
-    for repo_type in repo_types:
-        if repo_type in config:
-            original_config = config[repo_type]["known"]
-        else:
-            original_config = ""
-            config.add_section(repo_type)
-
-        if "known" not in config[repo_type] or repo not in config[repo_type]["known"].split("\n"):
-            config.set(repo_type, "known", f"{original_config}\n{repo}")
-
-    with open(REPO_TYPES_CFG, "w") as config_file:
-        config.write(config_file)

--- a/src/repo_man/commands/add.py
+++ b/src/repo_man/commands/add.py
@@ -1,0 +1,36 @@
+import configparser
+from pathlib import Path
+
+import click
+
+from repo_man.consts import REPO_TYPES_CFG
+from repo_man.utils import pass_config
+
+
+@click.command
+@click.option("-t", "--type", "repo_types", multiple=True, help="The type of the repository", required=True)
+@click.argument("repo", type=click.Path(exists=True, file_okay=False))
+@pass_config
+def add(config: configparser.ConfigParser, repo: str, repo_types: list[str]):
+    """Add a new repository"""
+
+    if not Path(REPO_TYPES_CFG).exists():
+        click.confirm(click.style(f"No {REPO_TYPES_CFG} file found. Do you want to continue?", fg="yellow"), abort=True)
+
+    new_types = [repo_type for repo_type in repo_types if repo_type not in config]
+    if new_types:
+        message = "\n\t".join(new_types)
+        click.confirm(f"The following types are unknown and will be added:\n\n\t{message}\n\nContinue?", abort=True)
+
+    for repo_type in repo_types:
+        if repo_type in config:
+            original_config = config[repo_type]["known"]
+        else:
+            original_config = ""
+            config.add_section(repo_type)
+
+        if "known" not in config[repo_type] or repo not in config[repo_type]["known"].split("\n"):
+            config.set(repo_type, "known", f"{original_config}\n{repo}")
+
+    with open(REPO_TYPES_CFG, "w") as config_file:
+        config.write(config_file)

--- a/src/repo_man/commands/edit.py
+++ b/src/repo_man/commands/edit.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import click
+
+from repo_man.consts import REPO_TYPES_CFG
+
+
+@click.command
+def edit():
+    """Edit the repo-man configuration manually"""
+
+    if not Path(REPO_TYPES_CFG).exists():
+        click.echo(click.style(f"No {REPO_TYPES_CFG} file found.", fg="red"))
+        return
+
+    click.edit(filename=REPO_TYPES_CFG)

--- a/src/repo_man/commands/flavors.py
+++ b/src/repo_man/commands/flavors.py
@@ -1,0 +1,29 @@
+import configparser
+from pathlib import Path
+
+import click
+
+from repo_man.consts import REPO_TYPES_CFG
+from repo_man.utils import pass_config
+
+
+@click.command
+@click.argument("repo", type=click.Path(exists=True, file_okay=False))
+@pass_config
+def flavors(config: configparser.ConfigParser, repo: str):
+    """List the configured types for a repository"""
+
+    if not Path(REPO_TYPES_CFG).exists():
+        click.echo(click.style(f"No {REPO_TYPES_CFG} file found.", fg="red"))
+        return
+
+    found = set()
+
+    for section in config.sections():
+        if section == "ignore":
+            continue
+        if repo in config[section]["known"].split("\n"):
+            found.add(section)
+
+    for repository in sorted(found):
+        click.echo(repository)

--- a/src/repo_man/commands/implode.py
+++ b/src/repo_man/commands/implode.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import click
+
+from repo_man.consts import REPO_TYPES_CFG
+
+
+@click.command
+@click.argument("path", type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path))
+def implode(path: Path):
+    """Remove repo-man configuration for the specified directory"""
+
+    click.confirm(click.style("Are you sure you want to do this?", fg="yellow"), abort=True)
+    (path / REPO_TYPES_CFG).unlink(missing_ok=True)

--- a/src/repo_man/commands/init.py
+++ b/src/repo_man/commands/init.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import click
+
+from repo_man.consts import REPO_TYPES_CFG
+
+
+@click.command
+@click.argument("path", type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path))
+def init(path: Path):
+    """Initialize repo-man to track repositories located at the specified path"""
+
+    if (path / REPO_TYPES_CFG).exists():
+        click.confirm(
+            click.style(f"{REPO_TYPES_CFG} file already exists. Overwrite with empty configuration?", fg="yellow"),
+            abort=True,
+        )
+
+    with open(path / REPO_TYPES_CFG, "w"):
+        pass

--- a/src/repo_man/commands/list_repos.py
+++ b/src/repo_man/commands/list_repos.py
@@ -1,0 +1,27 @@
+import configparser
+from pathlib import Path
+
+import click
+
+from repo_man.consts import REPO_TYPES_CFG
+from repo_man.utils import get_valid_repo_types, parse_repo_types, pass_config
+
+
+@click.command(name="list", help="The type of repository to manage")
+@click.option("-t", "--type", "repo_type", type=click.Choice(get_valid_repo_types()), show_choices=False, required=True)
+@pass_config
+def list_repos(config: configparser.ConfigParser, repo_type: str):
+    """List matching repositories"""
+
+    if not Path(REPO_TYPES_CFG).exists():
+        click.echo(click.style(f"No {REPO_TYPES_CFG} file found.", fg="red"))
+        return
+
+    valid_repo_types = parse_repo_types(config)
+
+    repos = sorted(valid_repo_types[repo_type])
+
+    if len(repos) > 25:
+        click.echo_via_pager("\n".join(repos))
+    else:
+        click.echo("\n".join(repos))

--- a/src/repo_man/commands/sniff.py
+++ b/src/repo_man/commands/sniff.py
@@ -1,0 +1,46 @@
+import configparser
+from pathlib import Path
+
+import click
+
+from repo_man.utils import parse_repo_types, pass_config
+
+
+@click.command
+@click.option("-k", "--known", is_flag=True, help="List known repository types")
+@click.option("-u", "--unconfigured", is_flag=True, help="List repositories without a configured type")
+@click.option("-d", "--duplicates", is_flag=True, help="List repositories with more than one configured type")
+@pass_config
+def sniff(config: configparser.ConfigParser, known: bool, unconfigured: bool, duplicates: bool):
+    """Show information and potential issues with configuration"""
+
+    path = Path(".")
+    valid_repo_types = parse_repo_types(config)
+
+    if known:
+        known_repo_types = sorted(
+            [repo_type for repo_type in valid_repo_types if repo_type != "all" and repo_type != "ignore"]
+        )
+        for repo_type in known_repo_types:
+            click.echo(repo_type)
+
+    if unconfigured:
+        for directory in sorted(path.iterdir()):
+            if (
+                directory.is_dir()
+                and str(directory) not in valid_repo_types["all"]
+                and str(directory) not in valid_repo_types.get("ignore", [])
+            ):
+                click.echo(directory)
+
+    if duplicates:
+        seen_repos = set()
+        duplicate_repos = set()
+        for repo_type in valid_repo_types:
+            if repo_type != "all" and repo_type != "ignore":
+                for repo in valid_repo_types[repo_type]:
+                    if repo in seen_repos:
+                        duplicate_repos.add(repo)
+                    seen_repos.add(repo)
+
+        click.echo("\n".join(sorted(duplicate_repos)))

--- a/src/repo_man/consts.py
+++ b/src/repo_man/consts.py
@@ -1,0 +1,1 @@
+REPO_TYPES_CFG = "repo-man.cfg"

--- a/src/repo_man/utils.py
+++ b/src/repo_man/utils.py
@@ -1,0 +1,26 @@
+import configparser
+
+import click
+
+from repo_man.consts import REPO_TYPES_CFG
+
+
+pass_config = click.make_pass_decorator(configparser.ConfigParser)
+
+
+def parse_repo_types(config: configparser.ConfigParser) -> dict[str, set[str]]:
+    repo_types: dict[str, set[str]] = {"all": set()}
+    for section in config.sections():
+        repos = {repo for repo in config[section]["known"].split("\n") if repo}
+        repo_types[section] = repos
+        if section != "ignore":
+            repo_types["all"].update(repos)
+
+    return repo_types
+
+
+def get_valid_repo_types():
+    config = configparser.ConfigParser()
+    config.read(REPO_TYPES_CFG)
+    valid_repo_types = parse_repo_types(config)
+    return sorted(set(valid_repo_types.keys()))

--- a/test/test_add.py
+++ b/test/test_add.py
@@ -15,20 +15,26 @@ def test_add_clean_confirm():
         config.read("repo-man.cfg")
         result = runner.invoke(add, ["some-repo", "-t", "some-type"], input="Y\nY\n", obj=config)
         assert result.exit_code == 0
-        assert result.output == """No repo-man.cfg file found. Do you want to continue? [y/N]: Y
+        assert (
+            result.output
+            == """No repo-man.cfg file found. Do you want to continue? [y/N]: Y
 The following types are unknown and will be added:
 
 	some-type
 
 Continue? [y/N]: Y
 """
+        )
 
         with open("repo-man.cfg") as config_file:
-            assert config_file.read() == """[some-type]
+            assert (
+                config_file.read()
+                == """[some-type]
 known = 
 	some-repo
 
 """
+            )
 
 
 def test_add_clean_no_confirm_new_file():
@@ -40,9 +46,12 @@ def test_add_clean_no_confirm_new_file():
         config.read("repo-man.cfg")
         result = runner.invoke(add, ["some-repo", "-t", "some-type"], input="\n", obj=config)
         assert result.exit_code == 1
-        assert result.output == """No repo-man.cfg file found. Do you want to continue? [y/N]: 
+        assert (
+            result.output
+            == """No repo-man.cfg file found. Do you want to continue? [y/N]: 
 Aborted!
 """
+        )
 
 
 def test_add_with_existing_file():
@@ -50,25 +59,32 @@ def test_add_with_existing_file():
 
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
-            config_file.write("""[foo]
+            config_file.write(
+                """[foo]
 known =
     bar
-""")
+"""
+            )
 
         (Path(".") / "some-repo").mkdir()
         config = configparser.ConfigParser()
         config.read("repo-man.cfg")
         result = runner.invoke(add, ["some-repo", "-t", "some-type"], input="Y\n", obj=config)
         assert result.exit_code == 0
-        assert result.output == """The following types are unknown and will be added:
+        assert (
+            result.output
+            == """The following types are unknown and will be added:
 
 	some-type
 
 Continue? [y/N]: Y
 """
+        )
 
         with open("repo-man.cfg") as config_file:
-            assert config_file.read() == """[foo]
+            assert (
+                config_file.read()
+                == """[foo]
 known = 
 	bar
 
@@ -77,6 +93,7 @@ known =
 	some-repo
 
 """
+            )
 
 
 def test_add_with_existing_file_and_type():
@@ -84,10 +101,12 @@ def test_add_with_existing_file_and_type():
 
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
-            config_file.write("""[some-type]
+            config_file.write(
+                """[some-type]
 known =
     bar
-""")
+"""
+            )
 
         (Path(".") / "some-repo").mkdir()
         config = configparser.ConfigParser()
@@ -97,12 +116,15 @@ known =
         assert result.output == ""
 
         with open("repo-man.cfg") as config_file:
-            assert config_file.read() == """[some-type]
+            assert (
+                config_file.read()
+                == """[some-type]
 known = 
 	bar
 	some-repo
 
 """
+            )
 
 
 def test_add_multiple_types():
@@ -110,25 +132,32 @@ def test_add_multiple_types():
 
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
-            config_file.write("""[some-type]
+            config_file.write(
+                """[some-type]
 known =
     bar
-""")
+"""
+            )
 
         (Path(".") / "some-repo").mkdir()
         config = configparser.ConfigParser()
         config.read("repo-man.cfg")
         result = runner.invoke(add, ["some-repo", "-t", "some-type", "-t", "some-other-type"], input="Y\n", obj=config)
         assert result.exit_code == 0
-        assert result.output == """The following types are unknown and will be added:
+        assert (
+            result.output
+            == """The following types are unknown and will be added:
 
 	some-other-type
 
 Continue? [y/N]: Y
 """
+        )
 
         with open("repo-man.cfg") as config_file:
-            assert config_file.read() == """[some-type]
+            assert (
+                config_file.read()
+                == """[some-type]
 known = 
 	bar
 	some-repo
@@ -138,6 +167,7 @@ known =
 	some-repo
 
 """
+            )
 
 
 def test_add_no_action_needed():
@@ -145,10 +175,12 @@ def test_add_no_action_needed():
 
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
-            config_file.write("""[some-type]
+            config_file.write(
+                """[some-type]
 known =
     some-repo
-""")
+"""
+            )
 
         (Path(".") / "some-repo").mkdir()
         config = configparser.ConfigParser()
@@ -158,8 +190,11 @@ known =
         assert result.output == ""
 
         with open("repo-man.cfg") as config_file:
-            assert config_file.read() == """[some-type]
+            assert (
+                config_file.read()
+                == """[some-type]
 known = 
 	some-repo
 
 """
+            )

--- a/test/test_add.py
+++ b/test/test_add.py
@@ -1,0 +1,165 @@
+import configparser
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from repo_man.commands.add import add
+
+
+def test_add_clean_confirm():
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        (Path(".") / "some-repo").mkdir()
+        config = configparser.ConfigParser()
+        config.read("repo-man.cfg")
+        result = runner.invoke(add, ["some-repo", "-t", "some-type"], input="Y\nY\n", obj=config)
+        assert result.exit_code == 0
+        assert result.output == """No repo-man.cfg file found. Do you want to continue? [y/N]: Y
+The following types are unknown and will be added:
+
+	some-type
+
+Continue? [y/N]: Y
+"""
+
+        with open("repo-man.cfg") as config_file:
+            assert config_file.read() == """[some-type]
+known = 
+	some-repo
+
+"""
+
+
+def test_add_clean_no_confirm_new_file():
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        (Path(".") / "some-repo").mkdir()
+        config = configparser.ConfigParser()
+        config.read("repo-man.cfg")
+        result = runner.invoke(add, ["some-repo", "-t", "some-type"], input="\n", obj=config)
+        assert result.exit_code == 1
+        assert result.output == """No repo-man.cfg file found. Do you want to continue? [y/N]: 
+Aborted!
+"""
+
+
+def test_add_with_existing_file():
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        with open("repo-man.cfg", "w") as config_file:
+            config_file.write("""[foo]
+known =
+    bar
+""")
+
+        (Path(".") / "some-repo").mkdir()
+        config = configparser.ConfigParser()
+        config.read("repo-man.cfg")
+        result = runner.invoke(add, ["some-repo", "-t", "some-type"], input="Y\n", obj=config)
+        assert result.exit_code == 0
+        assert result.output == """The following types are unknown and will be added:
+
+	some-type
+
+Continue? [y/N]: Y
+"""
+
+        with open("repo-man.cfg") as config_file:
+            assert config_file.read() == """[foo]
+known = 
+	bar
+
+[some-type]
+known = 
+	some-repo
+
+"""
+
+
+def test_add_with_existing_file_and_type():
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        with open("repo-man.cfg", "w") as config_file:
+            config_file.write("""[some-type]
+known =
+    bar
+""")
+
+        (Path(".") / "some-repo").mkdir()
+        config = configparser.ConfigParser()
+        config.read("repo-man.cfg")
+        result = runner.invoke(add, ["some-repo", "-t", "some-type"], obj=config)
+        assert result.exit_code == 0
+        assert result.output == ""
+
+        with open("repo-man.cfg") as config_file:
+            assert config_file.read() == """[some-type]
+known = 
+	bar
+	some-repo
+
+"""
+
+
+def test_add_multiple_types():
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        with open("repo-man.cfg", "w") as config_file:
+            config_file.write("""[some-type]
+known =
+    bar
+""")
+
+        (Path(".") / "some-repo").mkdir()
+        config = configparser.ConfigParser()
+        config.read("repo-man.cfg")
+        result = runner.invoke(add, ["some-repo", "-t", "some-type", "-t", "some-other-type"], input="Y\n", obj=config)
+        assert result.exit_code == 0
+        assert result.output == """The following types are unknown and will be added:
+
+	some-other-type
+
+Continue? [y/N]: Y
+"""
+
+        with open("repo-man.cfg") as config_file:
+            assert config_file.read() == """[some-type]
+known = 
+	bar
+	some-repo
+
+[some-other-type]
+known = 
+	some-repo
+
+"""
+
+
+def test_add_no_action_needed():
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        with open("repo-man.cfg", "w") as config_file:
+            config_file.write("""[some-type]
+known =
+    some-repo
+""")
+
+        (Path(".") / "some-repo").mkdir()
+        config = configparser.ConfigParser()
+        config.read("repo-man.cfg")
+        result = runner.invoke(add, ["some-repo", "-t", "some-type"], obj=config)
+        assert result.exit_code == 0
+        assert result.output == ""
+
+        with open("repo-man.cfg") as config_file:
+            assert config_file.read() == """[some-type]
+known = 
+	some-repo
+
+"""

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from repo_man.cli import init
+
+
+def test_init_clean():
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        assert not Path("repo-man.cfg").exists()
+
+        result = runner.invoke(init, ["."])
+        assert result.exit_code == 0
+        assert result.output == ""
+        assert Path("repo-man.cfg").exists()
+
+
+def test_init_with_existing_confirm():
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        with open("repo-man.cfg", "w") as config_file:
+            config_file.write(
+                """[foo]
+known =
+    bar
+"""
+            )
+
+        result = runner.invoke(init, ["."], input="Y")
+        assert result.exit_code == 0
+        assert result.output == "repo-man.cfg file already exists. Overwrite with empty configuration? [y/N]: Y\n"
+
+        with open("repo-man.cfg") as config_file:
+            assert config_file.read() == ""
+
+
+def test_init_with_existing_no_confirm():
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        with open("repo-man.cfg", "w") as config_file:
+            config_file.write(
+                """[foo]
+known =
+    bar
+"""
+            )
+
+        result = runner.invoke(init, ["."], input="\n")
+        assert result.exit_code == 1
+        assert (
+            result.output == "repo-man.cfg file already exists. Overwrite with empty configuration? [y/N]: \nAborted!\n"
+        )
+
+        with open("repo-man.cfg") as config_file:
+            assert (
+                config_file.read()
+                == """[foo]
+known =
+    bar
+"""
+            )

--- a/test/test_repoman.py
+++ b/test/test_repoman.py
@@ -1,4 +1,0 @@
-def test_package_is_importable():
-    import repo_man
-
-    print(repo_man)


### PR DESCRIPTION
## Description of issue

Management of many commands in one module was starting to get difficult to reason about.

## Description of solution

Split commands into their own modules for better management.

- Add new init command
- Add new edit command
- Add new implode command
- Add new sniff command
- Add some unit tests
- Update validations/confirmations
