### PR TITLE
Add ability to list multiple repo types

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.0.7] - 2024-01-21
+
+### Added
+
+- `list` can now accept multiple `--type` parameters to list multiple repository types
+
 ## [0.0.6] - 2023-12-10
 
 ### Added

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = repo-man
-version = 0.0.6
+version = 0.0.7
 description = Manage repositories of different flavors.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/repo_man/commands/list_repos.py
+++ b/src/repo_man/commands/list_repos.py
@@ -18,14 +18,15 @@ def list_repos(config: configparser.ConfigParser, repo_types: list[str]):
         raise SystemExit(1)
 
     valid_repo_types = parse_repo_types(config)
-    repos = set()
+    found_repos = set()
+
     for repo_type in repo_types:
         if repo_type not in valid_repo_types:
             repo_list = "\n\t".join(valid_repo_types)
             raise click.BadParameter(f"Invalid repository type '{repo_type}'. Valid types are:\n\n\t{repo_list}")
-        repos.update(valid_repo_types[repo_type])
+        found_repos.update(valid_repo_types[repo_type])
 
-    repos = sorted(repos)
+    repos = sorted(found_repos)
 
     if len(repos) > 25:
         click.echo_via_pager("\n".join(repos))

--- a/src/repo_man/commands/list_repos.py
+++ b/src/repo_man/commands/list_repos.py
@@ -4,13 +4,13 @@ from pathlib import Path
 import click
 
 from repo_man.consts import REPO_TYPES_CFG
-from repo_man.utils import get_valid_repo_types, parse_repo_types, pass_config
+from repo_man.utils import parse_repo_types, pass_config
 
 
 @click.command(name="list", help="The type of repository to manage")
-@click.option("-t", "--type", "repo_type", type=click.Choice(get_valid_repo_types()), show_choices=False, required=True)
+@click.option("-t", "--type", "repo_types", multiple=True, show_choices=False, required=True)
 @pass_config
-def list_repos(config: configparser.ConfigParser, repo_type: str):
+def list_repos(config: configparser.ConfigParser, repo_types: list[str]):
     """List matching repositories"""
 
     if not Path(REPO_TYPES_CFG).exists():
@@ -18,8 +18,14 @@ def list_repos(config: configparser.ConfigParser, repo_type: str):
         raise SystemExit(1)
 
     valid_repo_types = parse_repo_types(config)
+    repos = set()
+    for repo_type in repo_types:
+        if repo_type not in valid_repo_types:
+            repo_list = "\n\t".join(valid_repo_types)
+            raise click.BadParameter(f"Invalid repository type '{repo_type}'. Valid types are:\n\n\t{repo_list}")
+        repos.update(valid_repo_types[repo_type])
 
-    repos = sorted(valid_repo_types[repo_type])
+    repos = sorted(repos)
 
     if len(repos) > 25:
         click.echo_via_pager("\n".join(repos))

--- a/test/test_list_repos.py
+++ b/test/test_list_repos.py
@@ -79,3 +79,31 @@ known =
         result = runner.invoke(list_repos, ["-t", "all"], obj=config)
         assert result.exit_code == 0
         mock_echo_via_pager.assert_called_once_with("\n".join(sorted(all_repos.split("\n"))))
+
+
+def test_list_repos_for_multiple_tags(runner, get_config):
+    with runner.isolated_filesystem():
+        with open("repo-man.cfg", "w") as config_file:
+            config_file.write(
+                """[foo]
+known = 
+    some-repo
+
+[bar]
+known = 
+    some-other-repo
+
+"""
+            )
+
+        config = get_config()
+        result = runner.invoke(list_repos, ["-t", "foo", "-t", "bar"], obj=config)
+        assert result.exit_code == 0
+        assert (
+            result.output
+            == """some-other-repo
+some-repo
+"""
+        )
+
+

--- a/test/test_list_repos.py
+++ b/test/test_list_repos.py
@@ -105,5 +105,3 @@ known =
 some-repo
 """
         )
-
-


### PR DESCRIPTION
## Description of issue

There might be cause to list multiple repository types in one go when you want to take an action across different slices of them.

## Description of solution

Allow multiple `--type` specifications when using `repo-man list`

This required moving away from using `click.Choice` because it doesn't afford dynamically determining the choices beyond import time, making this situation difficult to test; this was always the case, but wasn't caught until now because the existing tests were using `-t all` which is always a valid type.