### PR TITLE
Add ability to remove a repository from one or more types

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `remove` command to remove a repository from one or more types
+
 ## [0.0.7] - 2024-01-21
 
 ### Added

--- a/src/repo_man/cli.py
+++ b/src/repo_man/cli.py
@@ -8,6 +8,7 @@ from repo_man.commands.flavors import flavors
 from repo_man.commands.implode import implode
 from repo_man.commands.init import init
 from repo_man.commands.list_repos import list_repos
+from repo_man.commands.remove import remove
 from repo_man.commands.sniff import sniff
 from repo_man.consts import REPO_TYPES_CFG
 
@@ -30,5 +31,6 @@ def main():  # pragma: no cover
     cli.add_command(implode)
     cli.add_command(init)
     cli.add_command(list_repos)
+    cli.add_command(remove)
     cli.add_command(sniff)
     cli()

--- a/src/repo_man/commands/add.py
+++ b/src/repo_man/commands/add.py
@@ -1,10 +1,9 @@
 import configparser
-from pathlib import Path
 
 import click
 
 from repo_man.consts import REPO_TYPES_CFG
-from repo_man.utils import pass_config
+from repo_man.utils import pass_config, ensure_config_file_exists
 
 
 @click.command
@@ -14,8 +13,7 @@ from repo_man.utils import pass_config
 def add(config: configparser.ConfigParser, repo: str, repo_types: list[str]):
     """Add a new repository"""
 
-    if not Path(REPO_TYPES_CFG).exists():
-        click.confirm(click.style(f"No {REPO_TYPES_CFG} file found. Do you want to continue?", fg="yellow"), abort=True)
+    ensure_config_file_exists(confirm=True)
 
     new_types = [repo_type for repo_type in repo_types if repo_type not in config]
     if new_types:

--- a/src/repo_man/commands/edit.py
+++ b/src/repo_man/commands/edit.py
@@ -1,16 +1,13 @@
-from pathlib import Path
-
 import click
 
 from repo_man.consts import REPO_TYPES_CFG
+from repo_man.utils import ensure_config_file_exists
 
 
 @click.command
 def edit():
     """Edit the repo-man configuration manually"""
 
-    if not Path(REPO_TYPES_CFG).exists():
-        click.echo(click.style(f"No {REPO_TYPES_CFG} file found.", fg="red"))
-        raise SystemExit(1)
+    ensure_config_file_exists()
 
     click.edit(filename=REPO_TYPES_CFG)

--- a/src/repo_man/commands/flavors.py
+++ b/src/repo_man/commands/flavors.py
@@ -1,10 +1,8 @@
 import configparser
-from pathlib import Path
 
 import click
 
-from repo_man.consts import REPO_TYPES_CFG
-from repo_man.utils import pass_config
+from repo_man.utils import pass_config, ensure_config_file_exists
 
 
 @click.command
@@ -13,9 +11,7 @@ from repo_man.utils import pass_config
 def flavors(config: configparser.ConfigParser, repo: str):
     """List the configured types for a repository"""
 
-    if not Path(REPO_TYPES_CFG).exists():
-        click.echo(click.style(f"No {REPO_TYPES_CFG} file found.", fg="red"))
-        raise SystemExit(1)
+    ensure_config_file_exists()
 
     found = set()
 

--- a/src/repo_man/commands/list_repos.py
+++ b/src/repo_man/commands/list_repos.py
@@ -1,10 +1,8 @@
 import configparser
-from pathlib import Path
 
 import click
 
-from repo_man.consts import REPO_TYPES_CFG
-from repo_man.utils import parse_repo_types, pass_config
+from repo_man.utils import parse_repo_types, pass_config, ensure_config_file_exists
 
 
 @click.command(name="list", help="The type of repository to manage")
@@ -13,9 +11,7 @@ from repo_man.utils import parse_repo_types, pass_config
 def list_repos(config: configparser.ConfigParser, repo_types: list[str]):
     """List matching repositories"""
 
-    if not Path(REPO_TYPES_CFG).exists():
-        click.echo(click.style(f"No {REPO_TYPES_CFG} file found.", fg="red"))
-        raise SystemExit(1)
+    ensure_config_file_exists()
 
     valid_repo_types = parse_repo_types(config)
     found_repos = set()

--- a/src/repo_man/commands/remove.py
+++ b/src/repo_man/commands/remove.py
@@ -1,0 +1,35 @@
+import configparser
+from pathlib import Path
+
+import click
+
+from repo_man.consts import REPO_TYPES_CFG
+from repo_man.utils import parse_repo_types, pass_config
+
+
+@click.command
+@click.option("-t", "--type", "repo_types", multiple=True, help="The types from which to remove the repository")
+@click.argument("repo", type=click.Path(exists=True, file_okay=False))
+@pass_config
+def remove(config: configparser.ConfigParser, repo: str, repo_types: list[str]):
+    """Remove a repository from some or all types"""
+
+    if not Path(REPO_TYPES_CFG).exists():
+        raise click.UsageError(f"No {REPO_TYPES_CFG} file found.")
+
+    valid_repo_types = parse_repo_types(config)
+
+    for repo_type in repo_types:
+        if repo_type not in config:
+            repo_list = "\n\t".join(valid_repo_types)
+            raise click.BadParameter(f"Invalid repository type '{repo_type}'. Valid types are:\n\n\t{repo_list}")
+
+        if "known" not in config[repo_type] or repo not in config[repo_type]["known"].split("\n"):
+            click.confirm(f"Repository '{repo}' is not configured for type '{repo_type}'. Continue?", abort=True)
+
+        original_config = config[repo_type]["known"]
+        config.set(repo_type, "known", "\n".join(original_repo for original_repo in original_config.split("\n") if original_repo != repo))
+
+    with open(REPO_TYPES_CFG, "w") as config_file:
+        config.write(config_file)
+

--- a/src/repo_man/utils.py
+++ b/src/repo_man/utils.py
@@ -1,4 +1,5 @@
 import configparser
+from pathlib import Path
 
 import click
 
@@ -24,3 +25,14 @@ def get_valid_repo_types():
     config.read(REPO_TYPES_CFG)
     valid_repo_types = parse_repo_types(config)
     return sorted(set(valid_repo_types.keys()))
+
+
+def ensure_config_file_exists(confirm: bool = False) -> None:
+    if not Path(REPO_TYPES_CFG).exists():
+        if confirm:
+            click.confirm(
+                click.style(f"No {REPO_TYPES_CFG} file found. Do you want to continue?", fg="yellow"), abort=True
+            )
+        else:
+            click.echo(click.style(f"No {REPO_TYPES_CFG} file found.", fg="red"))
+            raise SystemExit(1)

--- a/test/test_list_repos.py
+++ b/test/test_list_repos.py
@@ -105,3 +105,31 @@ known =
 some-repo
 """
         )
+
+
+def test_list_repos_when_invalid_type(runner, get_config):
+    with runner.isolated_filesystem():
+        with open("repo-man.cfg", "w") as config_file:
+            config_file.write(
+                """[foo]
+known = 
+    some-repo
+
+[bar]
+known = 
+    some-other-repo
+
+"""
+            )
+
+        config = get_config()
+        result = runner.invoke(list_repos, ["-t", "baz"], obj=config)
+        assert result.exit_code == 2
+        assert result.output.endswith(
+            """Error: Invalid value: Invalid repository type 'baz'. Valid types are:
+
+\tall
+\tfoo
+\tbar
+"""
+        )

--- a/test/test_remove.py
+++ b/test/test_remove.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+from repo_man.commands.remove import remove
+
+
+def test_remove_clean(runner, get_config):
+    with runner.isolated_filesystem():
+        Path("some-repo").mkdir()
+
+        with open("repo-man.cfg", "w") as config_file:
+            config_file.write(
+                """[foo]
+known = 
+    some-repo
+"""
+            )
+
+        config = get_config()
+        result = runner.invoke(remove, ["-t", "foo", "some-repo"], obj=config)
+        assert result.exit_code == 0
+        assert result.output == ""
+
+        with open("repo-man.cfg") as config_file:
+            assert config_file.read() == "[foo]\nknown = \n\n"
+
+
+def test_remove_when_invalid_type(runner, get_config):
+    with runner.isolated_filesystem():
+        Path("some-repo").mkdir()
+
+        with open("repo-man.cfg", "w") as config_file:
+            config_file.write(
+                """[foo]
+known = 
+    some-repo
+"""
+            )
+
+        config = get_config()
+        result = runner.invoke(remove, ["-t", "bar", "some-repo"], obj=config)
+        assert result.exit_code == 2
+        assert result.output.endswith(
+            """Error: Invalid value: Invalid repository type 'bar'. Valid types are:
+
+\tall
+\tfoo
+"""
+        )
+
+        with open("repo-man.cfg") as config_file:
+            assert (
+                config_file.read()
+                == """[foo]
+known = 
+    some-repo
+"""
+            )
+
+
+def test_remove_when_unused_type(runner, get_config):
+    with runner.isolated_filesystem():
+        Path("some-repo").mkdir()
+
+        with open("repo-man.cfg", "w") as config_file:
+            config_file.write(
+                """[foo]
+known = 
+    some-repo
+
+[bar]
+known = 
+    some-other-repo
+"""
+            )
+
+        config = get_config()
+        result = runner.invoke(remove, ["-t", "bar", "some-repo"], obj=config)
+        assert result.exit_code == 1
+        assert (
+            result.output
+            == """Repository 'some-repo' is not configured for type 'bar'. Continue? [y/N]: 
+Aborted!
+"""
+        )

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,14 @@
+from repo_man.utils import get_valid_repo_types
+
+
+def test_get_valid_repo_types(runner):
+    with runner.isolated_filesystem():
+        with open("repo-man.cfg", "w") as config_file:
+            config_file.write(
+                """[foo]
+known = 
+    some-repo
+"""
+            )
+
+        assert get_valid_repo_types() == ["all", "foo"]


### PR DESCRIPTION
## Description of issue

- I added a repository to a type accidentally
- I no longer want to manage a particular repository

## Description of solution

Add a `remove` command to remove a repository from one or more types

We should consider that `remove` without any `-t` flags could list the types that the repository is currently tagged with, and confirm with the user that it will removed from all of them.
