### PR TITLE
Use strict typing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `remove` command to remove a repository from one or more types
 
+### Changed
+
+- Use `strict` for mypy type checking on source and tests
+
 ## [0.0.7] - 2024-01-21
 
 ### Added

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ docs =
 ######################
 
 [mypy]
+strict = True
 python_version = 3.10
 warn_unused_configs = True
 show_error_context = True

--- a/src/repo_man/cli.py
+++ b/src/repo_man/cli.py
@@ -16,7 +16,7 @@ from repo_man.consts import REPO_TYPES_CFG
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(package_name="repo-man")
 @click.pass_context
-def cli(context):  # pragma: no cover
+def cli(context: click.Context) -> None:  # pragma: no cover
     """Manage repositories of different types"""
 
     config = configparser.ConfigParser()
@@ -24,7 +24,7 @@ def cli(context):  # pragma: no cover
     context.obj = config
 
 
-def main():  # pragma: no cover
+def main() -> None:  # pragma: no cover
     cli.add_command(add)
     cli.add_command(edit)
     cli.add_command(flavors)

--- a/src/repo_man/commands/add.py
+++ b/src/repo_man/commands/add.py
@@ -10,7 +10,7 @@ from repo_man.utils import pass_config, ensure_config_file_exists
 @click.option("-t", "--type", "repo_types", multiple=True, help="The type of the repository", required=True)
 @click.argument("repo", type=click.Path(exists=True, file_okay=False))
 @pass_config
-def add(config: configparser.ConfigParser, repo: str, repo_types: list[str]):
+def add(config: configparser.ConfigParser, repo: str, repo_types: list[str]) -> None:
     """Add a new repository"""
 
     ensure_config_file_exists(confirm=True)

--- a/src/repo_man/commands/edit.py
+++ b/src/repo_man/commands/edit.py
@@ -5,7 +5,7 @@ from repo_man.utils import ensure_config_file_exists
 
 
 @click.command
-def edit():
+def edit() -> None:
     """Edit the repo-man configuration manually"""
 
     ensure_config_file_exists()

--- a/src/repo_man/commands/flavors.py
+++ b/src/repo_man/commands/flavors.py
@@ -8,7 +8,7 @@ from repo_man.utils import pass_config, ensure_config_file_exists
 @click.command
 @click.argument("repo", type=click.Path(exists=True, file_okay=False))
 @pass_config
-def flavors(config: configparser.ConfigParser, repo: str):
+def flavors(config: configparser.ConfigParser, repo: str) -> None:
     """List the configured types for a repository"""
 
     ensure_config_file_exists()

--- a/src/repo_man/commands/implode.py
+++ b/src/repo_man/commands/implode.py
@@ -7,7 +7,7 @@ from repo_man.consts import REPO_TYPES_CFG
 
 @click.command
 @click.argument("path", type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path))
-def implode(path: Path):
+def implode(path: Path) -> None:
     """Remove repo-man configuration for the specified directory"""
 
     click.confirm(click.style("Are you sure you want to do this?", fg="yellow"), abort=True)

--- a/src/repo_man/commands/init.py
+++ b/src/repo_man/commands/init.py
@@ -7,7 +7,7 @@ from repo_man.consts import REPO_TYPES_CFG
 
 @click.command
 @click.argument("path", type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path))
-def init(path: Path):
+def init(path: Path) -> None:
     """Initialize repo-man to track repositories located at the specified path"""
 
     if (path / REPO_TYPES_CFG).exists():

--- a/src/repo_man/commands/list_repos.py
+++ b/src/repo_man/commands/list_repos.py
@@ -8,7 +8,7 @@ from repo_man.utils import parse_repo_types, pass_config, ensure_config_file_exi
 @click.command(name="list", help="The type of repository to manage")
 @click.option("-t", "--type", "repo_types", multiple=True, show_choices=False, required=True)
 @pass_config
-def list_repos(config: configparser.ConfigParser, repo_types: list[str]):
+def list_repos(config: configparser.ConfigParser, repo_types: list[str]) -> None:
     """List matching repositories"""
 
     ensure_config_file_exists()

--- a/src/repo_man/commands/remove.py
+++ b/src/repo_man/commands/remove.py
@@ -10,7 +10,7 @@ from repo_man.utils import parse_repo_types, pass_config, ensure_config_file_exi
 @click.option("-t", "--type", "repo_types", multiple=True, help="The types from which to remove the repository")
 @click.argument("repo", type=click.Path(exists=True, file_okay=False))
 @pass_config
-def remove(config: configparser.ConfigParser, repo: str, repo_types: list[str]):
+def remove(config: configparser.ConfigParser, repo: str, repo_types: list[str]) -> None:
     """Remove a repository from some or all types"""
 
     ensure_config_file_exists()

--- a/src/repo_man/commands/sniff.py
+++ b/src/repo_man/commands/sniff.py
@@ -11,7 +11,7 @@ from repo_man.utils import parse_repo_types, pass_config
 @click.option("-u", "--unconfigured", is_flag=True, help="List repositories without a configured type")
 @click.option("-d", "--duplicates", is_flag=True, help="List repositories with more than one configured type")
 @pass_config
-def sniff(config: configparser.ConfigParser, known: bool, unconfigured: bool, duplicates: bool):
+def sniff(config: configparser.ConfigParser, known: bool, unconfigured: bool, duplicates: bool) -> None:
     """Show information and potential issues with configuration"""
 
     path = Path(".")

--- a/src/repo_man/utils.py
+++ b/src/repo_man/utils.py
@@ -20,7 +20,7 @@ def parse_repo_types(config: configparser.ConfigParser) -> dict[str, set[str]]:
     return repo_types
 
 
-def get_valid_repo_types():
+def get_valid_repo_types() -> list[str]:
     config = configparser.ConfigParser()
     config.read(REPO_TYPES_CFG)
     valid_repo_types = parse_repo_types(config)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 import configparser
+from typing import Callable
 
 import pytest
 from click.testing import CliRunner
@@ -7,13 +8,13 @@ from repo_man.consts import REPO_TYPES_CFG
 
 
 @pytest.fixture
-def runner():
+def runner() -> CliRunner:
     return CliRunner()
 
 
 @pytest.fixture
-def get_config():
-    def func():
+def get_config() -> Callable[[], configparser.ConfigParser]:
+    def func() -> configparser.ConfigParser:
         config = configparser.ConfigParser()
         config.read(REPO_TYPES_CFG)
         return config

--- a/test/test_add.py
+++ b/test/test_add.py
@@ -1,9 +1,15 @@
+import configparser
 from pathlib import Path
+from typing import Callable
+
+import click
 
 from repo_man.commands.add import add
 
 
-def test_add_clean_confirm(runner, get_config):
+def test_add_clean_confirm(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         (Path(".") / "some-repo").mkdir()
         config = get_config()
@@ -31,7 +37,9 @@ known =
             )
 
 
-def test_add_clean_no_confirm_new_file(runner, get_config):
+def test_add_clean_no_confirm_new_file(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         (Path(".") / "some-repo").mkdir()
         config = get_config()
@@ -45,7 +53,9 @@ Aborted!
         )
 
 
-def test_add_with_existing_file(runner, get_config):
+def test_add_with_existing_file(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
             config_file.write(
@@ -84,7 +94,9 @@ known =
             )
 
 
-def test_add_with_existing_file_and_type(runner, get_config):
+def test_add_with_existing_file_and_type(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
             config_file.write(
@@ -112,7 +124,9 @@ known =
             )
 
 
-def test_add_multiple_types(runner, get_config):
+def test_add_multiple_types(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
             config_file.write(
@@ -152,7 +166,9 @@ known =
             )
 
 
-def test_add_no_action_needed(runner, get_config):
+def test_add_no_action_needed(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
             config_file.write(

--- a/test/test_edit.py
+++ b/test/test_edit.py
@@ -1,10 +1,12 @@
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, Mock
+
+import click
 
 from repo_man.commands import edit
 
 
-def test_edit_clean(runner):
+def test_edit_clean(runner: click.testing.CliRunner) -> None:
     with runner.isolated_filesystem():
         result = runner.invoke(edit.edit)
         assert result.exit_code == 1
@@ -12,7 +14,7 @@ def test_edit_clean(runner):
 
 
 @patch("repo_man.commands.edit.click.edit")
-def test_edit_when_config_present(mock_edit, runner):
+def test_edit_when_config_present(mock_edit: Mock, runner: click.testing.CliRunner) -> None:
     with runner.isolated_filesystem():
         Path("repo-man.cfg").touch()
         result = runner.invoke(edit.edit)

--- a/test/test_flavors.py
+++ b/test/test_flavors.py
@@ -1,9 +1,13 @@
+import configparser
 from pathlib import Path
+from typing import Callable
+
+import click
 
 from repo_man.commands.flavors import flavors
 
 
-def test_flavors_clean(runner, get_config):
+def test_flavors_clean(runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]) -> None:
     with runner.isolated_filesystem():
         Path("some-repo").mkdir()
         config = get_config()
@@ -12,7 +16,9 @@ def test_flavors_clean(runner, get_config):
         assert result.output == "No repo-man.cfg file found.\n"
 
 
-def test_flavors_when_configured(runner, get_config):
+def test_flavors_when_configured(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         Path("some-repo").mkdir()
 
@@ -35,7 +41,9 @@ known =
         assert result.output == "foo\n"
 
 
-def test_flavors_when_not_configured(runner, get_config):
+def test_flavors_when_not_configured(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         Path("some-repo").mkdir()
 
@@ -54,7 +62,9 @@ known =
         assert result.output == ""
 
 
-def test_flavors_when_ignored(runner, get_config):
+def test_flavors_when_ignored(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         Path("some-repo").mkdir()
 

--- a/test/test_implode.py
+++ b/test/test_implode.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 
+import click
+
 from repo_man.commands.implode import implode
 
 
-def test_implode_when_config_present_confirm(runner):
+def test_implode_when_config_present_confirm(runner: click.testing.CliRunner) -> None:
     with runner.isolated_filesystem():
         Path("repo-man.cfg").touch()
 
@@ -13,14 +15,14 @@ def test_implode_when_config_present_confirm(runner):
         assert not Path("repo-man.cfg").exists()
 
 
-def test_implode_when_config_not_present_confirm(runner):
+def test_implode_when_config_not_present_confirm(runner: click.testing.CliRunner) -> None:
     with runner.isolated_filesystem():
         result = runner.invoke(implode, ["."], input="Y\n")
         assert result.exit_code == 0
         assert result.output == "Are you sure you want to do this? [y/N]: Y\n"
 
 
-def test_implode_when_config_present_no_confirm(runner):
+def test_implode_when_config_present_no_confirm(runner: click.testing.CliRunner) -> None:
     with runner.isolated_filesystem():
         Path("repo-man.cfg").touch()
 

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 
-from repo_man.cli import init
+import click
+
+from repo_man.commands.init import init
 
 
-def test_init_clean(runner):
+def test_init_clean(runner: click.testing.CliRunner) -> None:
     with runner.isolated_filesystem():
         assert not Path("repo-man.cfg").exists()
 
@@ -13,7 +15,7 @@ def test_init_clean(runner):
         assert Path("repo-man.cfg").exists()
 
 
-def test_init_with_existing_confirm(runner):
+def test_init_with_existing_confirm(runner: click.testing.CliRunner) -> None:
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
             config_file.write(
@@ -31,7 +33,7 @@ known =
             assert config_file.read() == ""
 
 
-def test_init_with_existing_no_confirm(runner):
+def test_init_with_existing_no_confirm(runner: click.testing.CliRunner) -> None:
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
             config_file.write(

--- a/test/test_list_repos.py
+++ b/test/test_list_repos.py
@@ -1,9 +1,13 @@
-from unittest.mock import patch
+import configparser
+from unittest.mock import patch, Mock
+from typing import Callable
+
+import click
 
 from repo_man.commands.list_repos import list_repos
 
 
-def test_list_repos_clean(runner, get_config):
+def test_list_repos_clean(runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]) -> None:
     with runner.isolated_filesystem():
         config = get_config()
         result = runner.invoke(list_repos, ["-t", "all"], obj=config)
@@ -11,7 +15,9 @@ def test_list_repos_clean(runner, get_config):
         assert result.output == "No repo-man.cfg file found.\n"
 
 
-def test_list_repos_with_matches(runner, get_config):
+def test_list_repos_with_matches(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
             config_file.write(
@@ -35,7 +41,9 @@ some-repo
 
 
 @patch("repo_man.commands.list_repos.click.echo_via_pager")
-def test_list_repos_when_long(mock_echo_via_pager, runner, get_config):
+def test_list_repos_when_long(
+    mock_echo_via_pager: Mock, runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     all_repos = """some-repo-1
 some-repo-2
 some-repo-3
@@ -81,7 +89,9 @@ known =
         mock_echo_via_pager.assert_called_once_with("\n".join(sorted(all_repos.split("\n"))))
 
 
-def test_list_repos_for_multiple_tags(runner, get_config):
+def test_list_repos_for_multiple_tags(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
             config_file.write(
@@ -107,7 +117,9 @@ some-repo
         )
 
 
-def test_list_repos_when_invalid_type(runner, get_config):
+def test_list_repos_when_invalid_type(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
             config_file.write(

--- a/test/test_remove.py
+++ b/test/test_remove.py
@@ -1,9 +1,13 @@
+import configparser
 from pathlib import Path
+from typing import Callable
+
+import click
 
 from repo_man.commands.remove import remove
 
 
-def test_remove_clean(runner, get_config):
+def test_remove_clean(runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]) -> None:
     with runner.isolated_filesystem():
         Path("some-repo").mkdir()
 
@@ -24,7 +28,9 @@ known =
             assert config_file.read() == "[foo]\nknown = \n\n"
 
 
-def test_remove_when_invalid_type(runner, get_config):
+def test_remove_when_invalid_type(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         Path("some-repo").mkdir()
 
@@ -57,7 +63,9 @@ known =
             )
 
 
-def test_remove_when_unused_type(runner, get_config):
+def test_remove_when_unused_type(
+    runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]
+) -> None:
     with runner.isolated_filesystem():
         Path("some-repo").mkdir()
 

--- a/test/test_sniff.py
+++ b/test/test_sniff.py
@@ -1,9 +1,13 @@
+import configparser
 from pathlib import Path
+from typing import Callable
+
+import click
 
 from repo_man.commands.sniff import sniff
 
 
-def test_known(runner, get_config):
+def test_known(runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]) -> None:
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
             config_file.write(
@@ -30,7 +34,7 @@ known =
         assert result.output == "bar\nfoo\n"
 
 
-def test_unconfigured(runner, get_config):
+def test_unconfigured(runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]) -> None:
     with runner.isolated_filesystem():
         Path("some-repo").mkdir()
         Path("some-other-repo").mkdir()
@@ -51,7 +55,7 @@ known =
         assert result.output == "some-other-repo\n"
 
 
-def test_duplicates(runner, get_config):
+def test_duplicates(runner: click.testing.CliRunner, get_config: Callable[[], configparser.ConfigParser]) -> None:
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
             config_file.write(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,9 @@
+import click
+
 from repo_man.utils import get_valid_repo_types
 
 
-def test_get_valid_repo_types(runner):
+def test_get_valid_repo_types(runner: click.testing.CliRunner) -> None:
     with runner.isolated_filesystem():
         with open("repo-man.cfg", "w") as config_file:
             config_file.write(


### PR DESCRIPTION
## Description of issue

Typing is good. Forgetting to do typing is bad.

## Description of solution

Ensure we remember to add type hints always by using `strict`.

There is contention in the community about whether to type tests, but I find it worthwhile. Especially when pytest fixtures occasionally cause hiccups during development (e.g. by referencing a fixture that hasn't been added as a test function argument), typing can sometimes help figure that out more quickly.