### PR TITLE
Fix help strings and consistently use docstrings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.0.8] - 2024-02-012
+## [0.0.9] - 2024-04-17
+
+### Fixed
+
+- Fix incorrect help string for the `list` command
+
+## [0.0.8] - 2024-02-12
 
 ### Added
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = repo-man
-version = 0.0.8
+version = 0.0.9
 description = Manage repositories of a variety of different types.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/repo_man/commands/list_repos.py
+++ b/src/repo_man/commands/list_repos.py
@@ -5,7 +5,7 @@ import click
 from repo_man.utils import ensure_config_file_exists, parse_repo_types, pass_config
 
 
-@click.command(name="list", help="The type of repository to manage")
+@click.command(name="list")
 @click.option("-t", "--type", "repo_types", multiple=True, show_choices=False, required=True)
 @pass_config
 def list_repos(config: configparser.ConfigParser, repo_types: list[str]) -> None:

--- a/src/repo_man/commands/remove.py
+++ b/src/repo_man/commands/remove.py
@@ -6,7 +6,7 @@ from repo_man.consts import REPO_TYPES_CFG
 from repo_man.utils import ensure_config_file_exists, parse_repo_types, pass_config
 
 
-@click.command(name="remove", help="Remove a repository from one or more types")
+@click.command(name="remove")
 @click.option("-t", "--type", "repo_types", multiple=True, help="The types from which to remove the repository")
 @click.argument("repo", type=click.Path(exists=True, file_okay=False))
 @pass_config


### PR DESCRIPTION
## Description of issue

- One help string was an incorrect copypasta
- Two help strings were explicitly using the `help` kwarg instead of using the function's docstring

## Description of solution

- Remove explicit use of `help`, which allows the (correct) docstrings to be used
